### PR TITLE
ユーザー一覧表示機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,15 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [
-      :nickname, :kanji_family_name, :kanji_given_name,
-      :katakana_family_name, :katakana_given_name, :birthday
-    ])
+                                        :nickname, :kanji_family_name, :kanji_given_name,
+                                        :katakana_family_name, :katakana_given_name, :birthday
+                                      ])
+  end
+
+  def authenticate_admin_user!
+    # current_userがnilの場合はerrorが起きてしまうが、先にauthenticate_user!でnilかどうかを確認するようにする
+    return if current_user.admin?
+
+    redirect_to root_path
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,11 +37,4 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :price, :image)
   end
-
-  def authenticate_admin_user!
-    # current_userがnilの場合はerrorが起きてしまうが、先にauthenticate_user!でnilかどうかを確認するようにする
-    return if current_user.admin?
-
-    redirect_to root_path
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,21 +1,22 @@
 class UsersController < ApplicationController
   def index
-    # @users = User.all
+    @users = User.all
+    render 'admin_users/index'
   end
 
   def new
     @user = User.new
   end
 
-  def create
-    @user = User.new(user_params)
-    if @user.save
-      redirect_to items_path
-    else
-      render :new
-    end
-  end
+  # def create
+  #   @user = User.new(user_params)
+  #   if @user.save
+  #     redirect_to items_path
+  #   else
+  #     render :new
+  #   end
+  # end
 
-  def destroy
-  end
+  # def destroy
+  # end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!,       only: [:index]
+  before_action :authenticate_admin_user!, only: [:index]
   def index
     @users = User.all
     render 'admin_users/index'
@@ -7,16 +9,4 @@ class UsersController < ApplicationController
   def new
     @user = User.new
   end
-
-  # def create
-  #   @user = User.new(user_params)
-  #   if @user.save
-  #     redirect_to items_path
-  #   else
-  #     render :new
-  #   end
-  # end
-
-  # def destroy
-  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,10 +14,10 @@ class User < ApplicationRecord
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
   validates :password, format: { with: VALID_PASSWORD_REGEX }
 
-
   def admin?
-    # todo:admin_flagを追加したのちにコードを書き替える必要がある
+    # TODO: admin_flagを追加したのちにコードを書き替える必要がある
     # 現時点では、全ユーザーが管理者扱いになる
-    true
+    # true
+    false
   end
 end

--- a/app/views/admin_users/index.html.erb
+++ b/app/views/admin_users/index.html.erb
@@ -1,19 +1,12 @@
 <%= render "shared/second-header" %>
 
 <div class="container">
-  <%# ユーザー管理画面 全体レイアウト %>
   <div class="card-layout">
-
-    <%# ヘッダー部分：タイトル %>
     <div class="card-header">
       <h1 class="app-title">DemoEC ユーザー管理</h1>
     </div>
-    <%# /ヘッダー部分：タイトル %>
 
-    <%# ユーザー一覧の表示部分 %>
     <div class="user-list-container">
-
-      <%# ユーザー一覧の見出し %>
       <div class="user-list-header">
         <div>
           <h2 class="section-title">ユーザー一覧</h2>
@@ -22,9 +15,7 @@
           </p>
         </div>
       </div>
-      <%# /ユーザー一覧の見出し %>
 
-      <%# ユーザー一覧のテーブル %>
       <div class="user-table">
         <table>
           <thead>
@@ -37,11 +28,8 @@
           </thead>
           <tbody>
 
-            <%# ユーザーのインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
             <% @users.each do |user| %>
               <tr>
-
-                <%# ユーザー名・メールアドレスの表示 %>
                 <td class="user-col">
                   <div class="user-info">
                     <div class="avatar">
@@ -53,40 +41,26 @@
                     </div>
                   </div>
                 </td>
-                <%# /ユーザー名・メールアドレスの表示 %>
 
-                <%# 登録日の表示 %>
                 <td class="date-col">
                   <%= user.created_at.strftime("%Y-%m-%d") %>
                 </td>
-                <%# /登録日の表示 %>
 
-                <%# ユーザーの権限（管理者・一般ユーザー）の表示 %>
                 <td class="role-col">
                   <span class="role-badge <%= "管理者" ? 'admin' : 'user' %>">
                     <%= "管理者" ? '管理者' : '一般ユーザー' %>
                   </span>
                 </td>
-                <%# /ユーザーの権限（管理者・一般ユーザー）の表示 %>
 
-                <%# 退会ボタンの表示 %>
                 <td class="actions-col">
                   <%= link_to '退会', "#", method: :delete , class: "admin-action-button" %>
                 </td>
-                <%# /退会ボタンの表示 %>
 
               </tr>
             <% end %>
-            <%# //ユーザーのインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
           </tbody>
         </table>
       </div>
-      <%# /ユーザー一覧のテーブル %>
-
     </div>
-    <%# /ユーザー一覧の表示部分 %>
-
   </div>
-  <%# /ユーザー管理画面 全体レイアウト %>
 </div>

--- a/app/views/admin_users/index.html.erb
+++ b/app/views/admin_users/index.html.erb
@@ -18,7 +18,7 @@
         <div>
           <h2 class="section-title">ユーザー一覧</h2>
           <p class="section-description">
-            登録されているユーザーの一覧です。<%= "999" %>人のユーザーが見つかりました。
+            登録されているユーザーの一覧です。<%= @users.count %>人のユーザーが見つかりました。
           </p>
         </div>
       </div>
@@ -38,6 +38,7 @@
           <tbody>
 
             <%# ユーザーのインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+            <% @users.each do |user| %>
               <tr>
 
                 <%# ユーザー名・メールアドレスの表示 %>
@@ -47,8 +48,8 @@
                       <div class="avatar-fallback"></div>
                     </div>
                     <div class="user-details">
-                      <span class="nickname"><%= "ニックネーム" %></span>
-                      <span class="email"><%= "メールアドレス" %></span>
+                        <span class="nickname"><%= user.nickname %></span>
+                        <span class="email"><%= user.email %></span>
                     </div>
                   </div>
                 </td>
@@ -56,7 +57,7 @@
 
                 <%# 登録日の表示 %>
                 <td class="date-col">
-                  <%= "登録日" %>
+                  <%= user.created_at.strftime("%Y-%m-%d") %>
                 </td>
                 <%# /登録日の表示 %>
 
@@ -75,6 +76,7 @@
                 <%# /退会ボタンの表示 %>
 
               </tr>
+            <% end %>
             <%# //ユーザーのインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
           </tbody>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -23,7 +23,7 @@
             <%= link_to "#{current_user.nickname}さん", "#", class: 'user-nickname' %>
             <div class="dropdown-content">
               <% if current_user.admin? %>
-                <%= link_to 'ユーザー管理', "#", class: "user-admin" %>
+                <%= link_to 'ユーザー管理', users_path, class: "user-admin" %>
                 <%= link_to '商品管理', "#", class: "user-admin" %>
               <% end %>
       


### PR DESCRIPTION
# What
- 管理者ユーザーは、ユーザー管理ボタンからユーザー管理ページに遷移できるようにした
- ユーザー管理ページにはECサイトに登録したユーザーが登録順で表示できるようにした
- ユーザーの情報（ニックネーム、登録メールアドレス、登録日、ロール）が、見本アプリと同様の形で出力されるようにした
- ユーザー管理ページには、 ECサイトに登録したユーザー数が表示されること
- ログイン状態の一般ユーザーは、ユーザー管理ページへ遷移しようとすると、トップページへ遷移するようにした
- ログアウト状態のユーザーは、ユーザー管理ページへ遷移しようとすると、ログインページへ遷移するようにした

# Why
管理者ユーザーがユーザー一覧を表示できるようにするため