### PR TITLE
商品一覧ページの実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   # ログインしていない場合はログインページに強制遷移させる。
   # TODO: 管理者ユーザーで実際に挙動を確認する必要がある
-  before_action :authenticate_user!,       only: [:new]
-  before_action :authenticate_admin_user!, only: [:new]
+  before_action :authenticate_user!,       only: [:new, :dashboard]
+  before_action :authenticate_admin_user!, only: [:new, :dashboard]
 
   # トップページ
   def index
@@ -11,6 +11,8 @@ class ItemsController < ApplicationController
 
   # 商品管理・一覧ページ
   def dashboard
+    @items = Item.all
+    render 'items/dashboard'
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,6 +17,6 @@ class Item < ApplicationRecord
   def sold_out?
     # buyer_id.present?
     false
-    # todo:orderテーブルを実装した後に修正する必要あり
+    # TODO: orderテーブルを実装した後に修正する必要あり
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,119 +1,119 @@
 <%= render "shared/second-header"%>
 
 <%= form_with model:@user, class: 'registration-main', local: true do |f| %>
-<div class='form-container'>
-  <div class='form-header'>
-    <h1 class='form-title'>会員登録</h1>
-    <p class="form-subtitle">アカウントを作成して、スムーズなお買い物をお楽しみください</p>
+  <div class='form-container'>
+    <div class='form-header'>
+      <h1 class='form-title'>会員登録</h1>
+      <p class="form-subtitle">アカウントを作成して、スムーズなお買い物をお楽しみください</p>
+    </div>
+
+    <%= render 'shared/error_messages', model: f.object %>
+
+    <div class="form-section">
+      <h2 class="section-title">アカウント情報</h2>
+
+      <div class="form-group">
+        <div class='weight-bold-text'>
+          <label for="nickname">ニックネーム</label>
+          <span class="required-badge">必須</span>
+        </div>
+        <%= f.text_field :nickname, class:"form-input", id:"nickname", placeholder:"例) DemoEC太郎", maxlength:"40", autofocus: true %>
+      </div>
+
+      <div class="form-group">
+        <div class='weight-bold-text'>
+          <label for="email">メールアドレス</label>
+          <span class="required-badge">必須</span>
+        </div>
+        <%= f.email_field :email, class:"form-input", id:"email", placeholder:"メールアドレスを入力" %>
+      </div>
+
+      <div class="form-group">
+        <div class='weight-bold-text'>
+          <label for="password">パスワード</label>
+          <span class="required-badge">必須</span>
+        </div>
+        <%= f.password_field :password, class:"form-input", id:"password", placeholder:"6文字以上の半角英数字" %>
+        <p class='helper-text'>※英字と数字の両方を含めて設定してください</p>
+      </div>
+
+      <div class="form-group">
+        <div class='weight-bold-text'>
+          <label for="password-confirmation">パスワード(確認)</label>
+          <span class="required-badge">必須</span>
+        </div>
+        <%= f.password_field :password_confirmation, class:"form-input", id:"password-confirmation", placeholder:"同じパスワードを入力して下さい" %>
+      </div>
+    </div>
+
+    <div class="form-section">
+      <h2 class="section-title">個人情報</h2>
+      <div class="section-desc">
+        <i class="fa fa-info-circle"></i>
+        <p>安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。</p>
+      </div>
+
+      <div class="form-group">
+        <div class='weight-bold-text'>
+          <label>お名前(全角)</label>
+          <span class="required-badge">必須</span>
+        </div>
+        <div class='name-input-container'>
+          <%= f.text_field :kanji_family_name, class:"name-input", id:"last-name", placeholder:"姓" %>
+          <%= f.text_field :kanji_given_name, class:"name-input", id:"first-name", placeholder:"名" %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div class='weight-bold-text'>
+          <label>お名前カナ(全角)</label>
+          <span class="required-badge">必須</span>
+        </div>
+        <div class='name-input-container'>
+          <%= f.text_field :katakana_family_name, class:"name-input", id:"last-name-kana", placeholder:"セイ" %>
+          <%= f.text_field :katakana_given_name, class:"name-input", id:"first-name-kana", placeholder:"メイ" %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div class='weight-bold-text'>
+          <label for="date_of_birth">生年月日</label>
+          <span class="required-badge">必須</span>
+        </div>
+        <div class='birth-input-container'>
+          <%= raw sprintf(
+                    f.date_select(
+                      :birthday,
+                      class:'birth-select',
+                      id:"date_of_birth",
+                      use_month_numbers: true,
+                      prompt:'--',
+                      start_year: 1930,
+                      end_year: (Time.now.year - 5),
+                      date_separator: '%s'),
+                    "<span>年</span>", "<span>月</span>") + "<span>日</span>" %>
+        </div>
+        <p class='helper-text'>※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。</p>
+      </div>
+    </div>
+
+    <div class="terms-agreement">
+      <p>
+        「会員登録」のボタンを押すことにより、
+        <a href="#" class="terms-link">利用規約</a>
+        に同意したものとみなします
+      </p>
+    </div>
+
+    <div class='action-button'>
+      <%= f.submit "会員登録", class:"user-submit-button" %>
+    </div>
+
+    <div class="form-footer">
+      <a href="#" class="info-link">本人情報の登録について</a>
+      <a href="/users/sign_in" class="login-link">アカウントをお持ちの方はこちら</a>
+    </div>
   </div>
-
-  <%= render 'shared/error_messages', model: f.object %>
-
-  <div class="form-section">
-    <h2 class="section-title">アカウント情報</h2>
-
-    <div class="form-group">
-      <div class='weight-bold-text'>
-        <label for="nickname">ニックネーム</label>
-        <span class="required-badge">必須</span>
-      </div>
-      <%= f.text_field :nickname, class:"form-input", id:"nickname", placeholder:"例) DemoEC太郎", maxlength:"40", autofocus: true %>
-    </div>
-
-    <div class="form-group">
-      <div class='weight-bold-text'>
-        <label for="email">メールアドレス</label>
-        <span class="required-badge">必須</span>
-      </div>
-      <%= f.email_field :email, class:"form-input", id:"email", placeholder:"メールアドレスを入力" %>
-    </div>
-
-    <div class="form-group">
-      <div class='weight-bold-text'>
-        <label for="password">パスワード</label>
-        <span class="required-badge">必須</span>
-      </div>
-      <%= f.password_field :password, class:"form-input", id:"password", placeholder:"6文字以上の半角英数字" %>
-      <p class='helper-text'>※英字と数字の両方を含めて設定してください</p>
-    </div>
-
-    <div class="form-group">
-      <div class='weight-bold-text'>
-        <label for="password-confirmation">パスワード(確認)</label>
-        <span class="required-badge">必須</span>
-      </div>
-      <%= f.password_field :password_confirmation, class:"form-input", id:"password-confirmation", placeholder:"同じパスワードを入力して下さい" %>
-    </div>
-  </div>
-
-  <div class="form-section">
-    <h2 class="section-title">個人情報</h2>
-    <div class="section-desc">
-      <i class="fa fa-info-circle"></i>
-      <p>安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。</p>
-    </div>
-
-    <div class="form-group">
-      <div class='weight-bold-text'>
-        <label>お名前(全角)</label>
-        <span class="required-badge">必須</span>
-      </div>
-      <div class='name-input-container'>
-        <%= f.text_field :kanji_family_name, class:"name-input", id:"last-name", placeholder:"姓" %>
-        <%= f.text_field :kanji_given_name, class:"name-input", id:"first-name", placeholder:"名" %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <div class='weight-bold-text'>
-        <label>お名前カナ(全角)</label>
-        <span class="required-badge">必須</span>
-      </div>
-      <div class='name-input-container'>
-        <%= f.text_field :katakana_family_name, class:"name-input", id:"last-name-kana", placeholder:"セイ" %>
-        <%= f.text_field :katakana_given_name, class:"name-input", id:"first-name-kana", placeholder:"メイ" %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <div class='weight-bold-text'>
-        <label for="date_of_birth">生年月日</label>
-        <span class="required-badge">必須</span>
-      </div>
-      <div class='birth-input-container'>
-        <%= raw sprintf(
-                  f.date_select(
-                    :birthday,
-                    class:'birth-select',
-                    id:"date_of_birth",
-                    use_month_numbers: true,
-                    prompt:'--',
-                    start_year: 1930,
-                    end_year: (Time.now.year - 5),
-                    date_separator: '%s'),
-                  "<span>年</span>", "<span>月</span>") + "<span>日</span>" %>
-      </div>
-      <p class='helper-text'>※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。</p>
-    </div>
-  </div>
-
-  <div class="terms-agreement">
-    <p>
-      「会員登録」のボタンを押すことにより、
-      <a href="#" class="terms-link">利用規約</a>
-      に同意したものとみなします
-    </p>
-  </div>
-
-  <div class='action-button'>
-    <%= f.submit "会員登録", class:"user-submit-button" %>
-  </div>
-
-  <div class="form-footer">
-    <a href="#" class="info-link">本人情報の登録について</a>
-    <a href="/users/sign_in" class="login-link">アカウントをお持ちの方はこちら</a>
-  </div>
-</div>
 <% end %>
 
 <%= render "shared/second-footer"%>

--- a/app/views/items/dashboard.html.erb
+++ b/app/views/items/dashboard.html.erb
@@ -1,36 +1,25 @@
 <%= render "shared/second-header" %>
 
 <div class="container">
-  <%# 商品管理画面 全体レイアウト %>
   <div class="card-layout">
-
-    <%# ヘッダー部分：タイトル %>
     <div class="card-header">
       <h1 class="app-title">DemoEC 商品管理</h1>
     </div>
-    <%# /ヘッダー部分：タイトル %>
 
-    <%# 出品した商品一覧 %>
     <div class="item-list-container">
-
-      <%# 出品した商品の見出し %>
       <div class="item-list-header">
         <div>
           <h2 class="section-title">出品した商品一覧</h2>
           <p class="section-description">
-            出品されている商品の一覧です。<%= "999" %>個の商品が見つかりました。
+            出品されている商品の一覧です。<%= @items.count %>個の商品が見つかりました。
           </p>
         </div>
 
-        <%# 出品ボタン %>
         <div class="list-header-actions">
           <%= link_to '商品を出品する', "#", class: "new-item-button" %>
         </div>
-        <%# /出品ボタン %>
       </div>
-      <%# /出品した商品の見出し %>
 
-      <%# 商品テーブル %>
       <div class="item-table">
         <table>
           <thead>
@@ -42,68 +31,48 @@
               <th>アクション</th>
             </tr>
           </thead>
+
           <tbody>
-
-            <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+            <% @items.each do |item| %>
               <tr>
-
-                <%# 商品名・画像の表示 %>
                 <td class="item-col">
                   <div class="item-info">
                     <div class="item-avatar">
                       <div>
                         <%= image_tag "item-sample.png", class: "item-image" %>
-
-                        <%# 商品が売れている場合は "在庫なし" を表示 %>
+                        <% if item.sold_out? %>
                           <div class="sold-out">
                             <span>在庫なし</span>
                           </div>
-                        <%# /商品が売れている場合は "在庫なし" を表示 %>
+                        <% end %>
                       </div>
                     </div>
                     <div class="item-details">
-                      <span class="item-name"><%= "商品名" %></span>
+                      <span class="item-name"><%= item.name %></span>
                     </div>
                   </div>
                 </td>
-                <%# /商品名・画像の表示 %>
 
-                <%# 販売価格の表示 %>
                 <td class="price-col">
-                  <%= "販売価格" %>円
+                  <%= item.price %>円
                 </td>
-                <%# /販売価格の表示 %>
-
-                <%# カテゴリーの表示 %>
+                
                 <td class="category-col">
-                  <%= "カテゴリー名" %>
+                <%= item.category.name %>
                 </td>
-                <%# /カテゴリーの表示 %>
-
-                <%# 出品日の表示 %>
+                
                 <td class="date-col">
-                  <%= "出品日" %>
+                  <%= item.created_at.strftime("%Y-%m-%d") %>
                 </td>
-                <%# /出品日の表示 %>
-
-                <%# アクションボタン（編集・削除） %>
                 <td class="actions-col">
                   <%= link_to '編集', "#", class: "admin-action-button" %>
                   <%= link_to '削除', "#", method: :delete, class: "admin-action-button" %>
                 </td>
-                <%# /アクションボタン（編集・削除） %>
-
               </tr>
-            <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+            <% end %>
           </tbody>
         </table>
       </div>
-      <%# /商品テーブル %>
-
     </div>
-    <%# /出品した商品一覧 %>
-
   </div>
-  <%# /商品管理画面 全体レイアウト %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,7 +24,7 @@
             <div class="dropdown-content">
               <% if current_user.admin? %>
                 <%= link_to 'ユーザー管理', users_path, class: "user-admin" %>
-                <%= link_to '商品管理', "#", class: "user-admin" %>
+                <%= link_to '商品管理', dashboard_items_path, class: "user-admin" %>
               <% end %>
       
               <%# link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: "logout" %>


### PR DESCRIPTION
#What
- ヘッダーの管理者ユーザー名のプルダウン「商品管理」から、商品管理ページに遷移できるようにした
- 商品管理ページでは、商品管理ページ上に出品されている全ての商品が出品順に表示されるようにした
- 商品管理ページでは、商品管理ページ上に出品されている商品の個数が表示されるようにした
- 商品管理ページでは、商品出品時に登録した情報（商品画像/商品名/価格/カテゴリー/出品日）が、見本アプリと同様の形で出力されるようにした
- 売却済みの商品は、画像上に「在庫なし」の文字が表示されるようにした
- 一般ユーザーは、商品管理ページへ遷移しようとすると、トップページへ遷移するようにした
- ログアウト状態のユーザーは、商品管理ページへ遷移しようとすると、ログインページへ遷移するようにした

#Why
管理者ユーザーが商品管理機能を使用できるようにするため